### PR TITLE
fixes para compilar no ubuntu 24.04

### DIFF
--- a/engine/src/database.cpp
+++ b/engine/src/database.cpp
@@ -46,8 +46,8 @@ bool Database::connect()
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
-	uint8_t ssl_disabled = 0;
-    mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_disabled);
+	enum mysql_ssl_mode ssl_mode = SSL_MODE_DISABLED;
+    mysql_options(handle, MYSQL_OPT_SSL_MODE, &ssl_mode);
 
 	// connects to database
 	if (!mysql_real_connect(handle, g_config.getString(ConfigManager::MYSQL_HOST).c_str(), g_config.getString(ConfigManager::MYSQL_USER).c_str(), g_config.getString(ConfigManager::MYSQL_PASS).c_str(), g_config.getString(ConfigManager::MYSQL_DB).c_str(), g_config.getNumber(ConfigManager::SQL_PORT), g_config.getString(ConfigManager::MYSQL_SOCK).c_str(), 0)) {

--- a/engine/src/game.cpp
+++ b/engine/src/game.cpp
@@ -3832,7 +3832,7 @@ void Game::playerBuyStoreOffer(uint32_t playerId, const StoreOffer& offer, std::
 		player->updateCoinBalance();
 
 		player->sendStorePurchaseSuccessful(returnmessage.str(), IOAccount::getCoinBalance(player->getAccount()) );
-		IOAccount::registerTransaction(player->getAccount(), OS_TIME(nullptr), static_cast<uint8_t>(HISTORY_TYPE_NONE), thisOffer->getCount(true), static_cast<uint8_t>(thisOffer->getCoinType()), std::move(thisOffer->getName()), offerPrice);
+		IOAccount::registerTransaction(player->getAccount(), OS_TIME(nullptr), static_cast<uint8_t>(HISTORY_TYPE_NONE), thisOffer->getCount(true), static_cast<uint8_t>(thisOffer->getCoinType()), thisOffer->getName(), offerPrice);
 	} else {
 		player->sendStoreError(STORE_ERROR_PURCHASE, "Something went wrong with your purchase.");
 	}

--- a/engine/src/outputmessage.cpp
+++ b/engine/src/outputmessage.cpp
@@ -73,5 +73,5 @@ OutputMessage_ptr OutputMessagePool::getOutputMessage()
 {
 	// LockfreePoolingAllocator<void,...> will leave (void* allocate) ill-formed because
 	// of sizeof(T), so this guaranatees that only one list will be initialized
-	return std::allocate_shared<OutputMessage>(LockfreePoolingAllocator<void, OUTPUTMESSAGE_FREE_LIST_CAPACITY>());
+	return std::make_shared<OutputMessage>();
 }

--- a/engine/src/tools.cpp
+++ b/engine/src/tools.cpp
@@ -360,17 +360,26 @@ std::string convertIPToString(uint32_t ip)
 
 std::string formatDate(time_t time)
 {
-	const tm* tms = localtime(&time);
-	if (!tms) {
-		return {};
-	}
+    const tm* tms = localtime(&time);
+    if (!tms) {
+        return {};
+    }
 
-	char buffer[20];
-	int res = sprintf(buffer, "%02d/%02d/%04d %02d:%02d:%02d", tms->tm_mday, tms->tm_mon + 1, tms->tm_year + 1900, tms->tm_hour, tms->tm_min, tms->tm_sec);
-	if (res < 0) {
-		return {};
-	}
-	return {buffer, 19};
+    char buffer[32];
+    int res = snprintf(buffer, sizeof(buffer),
+        "%02d/%02d/%04d %02d:%02d:%02d",
+        tms->tm_mday,
+        tms->tm_mon + 1,
+        tms->tm_year + 1900,
+        tms->tm_hour,
+        tms->tm_min,
+        tms->tm_sec
+    );
+    if (res < 0 || res >= (int)sizeof(buffer)) {
+        return {};
+    }
+
+    return std::string(buffer);
 }
 
 std::string formatDateShort(time_t time)


### PR DESCRIPTION
Fiz algumas mudanças para conseguir compilar no ubuntu 24.04.

database.cpp:
Ajustei a flag e deixei desabilitado o SSL.
game.cpp:
std::move Obsoleto, o compilador já resolve. impedia a otimização copy elision na hora da compilação, causando erro. Removido. outputmessage.cpp:
allocate_shared -> make_shared C++ 20+
tools.cpp:
sprintf[20] -> snprintf[32] Compilador reclamava de possivel buffer overflow com buffer fixo [20] para datas. Agora possui verificação de limites e aumento do buffer.

Requisitos para compilação windows:
GCC 11 e C++17 ou superior.
Requisitos Linux:
GCC 11+

**Necessario testes e compilação no windows.**

GCC:
g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
SO:
Ubuntu 24.04.4 LTS